### PR TITLE
Update loofah to 2.2.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -62,7 +62,7 @@ GEM
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
       ruby_dep (~> 1.2)
-    loofah (2.2.0)
+    loofah (2.2.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     mail (2.7.0)


### PR DESCRIPTION
Got a vulnerability alert.

<img width="637" alt="screen shot 2018-03-22 at 8 35 47 am" src="https://user-images.githubusercontent.com/19860/37741183-229a6b6e-2dac-11e8-86ff-3eebcae456af.png">

<img width="932" alt="screen shot 2018-03-22 at 8 37 12 am" src="https://user-images.githubusercontent.com/19860/37741210-3952a998-2dac-11e8-949a-16ee644bb81d.png">

Wonder why dependabot hasn't told us about this?