### PR TITLE
 Switch to using slack_id to exclude users

### DIFF
--- a/app/models/list.rb
+++ b/app/models/list.rb
@@ -6,7 +6,7 @@ class List < ApplicationRecord
   validates :slack_channel_id, presence: true
 
   before_create :generate_webhook_token
-  
+
   def next_user(excluded_user_name = nil)
     list_users = users.alphabetically.cycle(2).to_a
     latest_task_user = tasks.not_archived.newest.first&.user

--- a/app/models/list.rb
+++ b/app/models/list.rb
@@ -7,13 +7,13 @@ class List < ApplicationRecord
 
   before_create :generate_webhook_token
 
-  def next_user(excluded_user_name = nil)
+  def next_user(excluded_slack_id = nil)
     list_users = users.alphabetically.cycle(2).to_a
     latest_task_user = tasks.not_archived.newest.first&.user
     next_index = list_users.index(latest_task_user)&.succ || 0
 
     next_user =
-      if list_users[next_index]&.slack_name == excluded_user_name
+      if list_users[next_index]&.slack_id == excluded_slack_id
         list_users[next_index.succ]
       else
         list_users[next_index]

--- a/app/operations/create_task_operation.rb
+++ b/app/operations/create_task_operation.rb
@@ -3,7 +3,11 @@ require "operation"
 class CreateTaskOperation < Operation::Base
   def call(params)
     list = List.find_by!(webhook_token: params[:list_webhook_token])
-    task = list.tasks.build(description: params[:description], user: list.next_user(params[:excluded_user_name]))
+    task = list.tasks.build(
+      description: params[:description],
+      user: list.next_user(params[:instigator_slack_id]),
+    )
+
     if task.save
       SlackMessage.new.post_task_assigned(task: task)
       success

--- a/db/migrate/20180428000401_add_unique_index_on_users_slack_id.rb
+++ b/db/migrate/20180428000401_add_unique_index_on_users_slack_id.rb
@@ -1,0 +1,5 @@
+class AddUniqueIndexOnUsersSlackId < ActiveRecord::Migration[5.1]
+  def change
+    add_index :users, :slack_id, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180406045858) do
+ActiveRecord::Schema.define(version: 20180428000401) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -47,6 +47,7 @@ ActiveRecord::Schema.define(version: 20180406045858) do
     t.string "slack_name", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["slack_id"], name: "index_users_on_slack_id", unique: true
   end
 
   add_foreign_key "lists_users", "lists"

--- a/spec/models/list_spec.rb
+++ b/spec/models/list_spec.rb
@@ -12,9 +12,8 @@ RSpec.describe List, type: :model do
 
   it "does not regenerate the webhook_token on update" do
     list = lists(:outofdate)
-    expect do
-      list.update!(name: "outofdate2")
-    end.to_not change { list.webhook_token }
+    expect { list.update!(name: "outofdate2") }
+      .not_to change { list.webhook_token }
   end
 
   describe "#next_user" do

--- a/spec/models/list_spec.rb
+++ b/spec/models/list_spec.rb
@@ -72,29 +72,33 @@ RSpec.describe List, type: :model do
 
     it "is the second user when we exclude the first user on a new list" do
       expect(list.tasks).to be_empty
-      expect(list.next_user).to eq(users(:aldhsu))
-      expect(list.next_user("aldhsu")).to eq(users(:alex))
+      allen = users(:aldhsu)
+      expect(list.next_user).to eq(allen)
+      expect(list.next_user(allen.slack_id)).to eq(users(:alex))
     end
 
     it "is not the excluded user even when their turn is due" do
       create_tasks(:aldhsu)
       expect(list.tasks.size).to eq(1)
-      expect(list.next_user).to eq(users(:alex))
-      expect(list.next_user("alex")).to eq(users(:dave))
+      alex = users(:alex)
+      expect(list.next_user).to eq(alex)
+      expect(list.next_user(alex.slack_id)).to eq(users(:dave))
     end
 
     it "is not the excluded user even when their turn is due, covering list cycle" do
       create_tasks(:aldhsu, :alex, :dave)
       expect(list.tasks.size).to eq(3)
-      expect(list.next_user).to eq(users(:tate))
-      expect(list.next_user("tatey")).to eq(users(:aldhsu))
+      tate = users(:tate)
+      expect(list.next_user).to eq(tate)
+      expect(list.next_user(tate.slack_id)).to eq(users(:aldhsu))
     end
 
     it "is not the excluded user even when their turn is due, covering list cycle" do
       create_tasks(:aldhsu, :alex, :dave, :tate)
       expect(list.tasks.size).to eq(4)
-      expect(list.next_user).to eq(users(:aldhsu))
-      expect(list.next_user("aldhsu")).to eq(users(:alex))
+      allen = users(:aldhsu)
+      expect(list.next_user).to eq(allen)
+      expect(list.next_user(allen.slack_id)).to eq(users(:alex))
     end
 
     it "is not affected by an irrelevant exclusion" do

--- a/spec/operations/create_task_operation_spec.rb
+++ b/spec/operations/create_task_operation_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe CreateTaskOperation do
           described_class.new.call(
             list_webhook_token: list.webhook_token,
             description: "asdf",
-            excluded_user_name: "aldhsu",
+            instigator_slack_id: users(:aldhsu).slack_id,
           )
         end.to change { Task.count }.by(1)
 

--- a/spec/operations/create_task_operation_spec.rb
+++ b/spec/operations/create_task_operation_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe CreateTaskOperation do
     end
 
     context "when excluding a user" do
-      let(:list){ lists(:outofdate) }
+      let(:list) { lists(:outofdate) }
 
       it "does not assign an excluded user" do
         expect(list.tasks).to be_empty
@@ -40,10 +40,10 @@ RSpec.describe CreateTaskOperation do
         expect do
           described_class.new.call(
             list_webhook_token: list.webhook_token,
-            description:"asdf",
-            excluded_user_name:"aldhsu",
+            description: "asdf",
+            excluded_user_name: "aldhsu",
           )
-        end.to change {Task.count}.by(1)
+        end.to change { Task.count }.by(1)
 
         expect(Task.last.user).to eq(users(:alex))
       end


### PR DESCRIPTION
The combination of Slack team ID and Slack user ID uniquely identify a Slack user. Since the bot only operates with a single team, `users.slack_id` uniquely identifies a user in Robin.

- added unique index on `users.slack_id`
- changed request parameter from `excluded_user_name` to `instigator_slack_id` in preparation for work Jack and I are doing
- updated `List#next_user` to compare against `slack_id`
- [x] checked that all users in our database have a unique `slack_id`