### PR TITLE
Migrate database on Heroku release

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
+release: LOG_LEVEL=debug bin/rails db:migrate
 web: bin/rails server -p $PORT -b 0.0.0.0


### PR DESCRIPTION
I realised the database wasn't being migrated by CI, so `db:migrate` was added as a release command.