### PR TITLE
Fix ordered users

### DIFF
--- a/app/models/list.rb
+++ b/app/models/list.rb
@@ -9,7 +9,7 @@ class List < ApplicationRecord
 
   def ordered_users
     list_users = users.alphabetically.to_a
-    latest_task_user = tasks.not_archived.newest.first&.user
+    latest_task_user = tasks.exclude_unassigned.not_archived.newest.first&.user
     count = list_users.index(latest_task_user)&.succ || 0
     list_users.rotate(count)
   end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -9,6 +9,7 @@ class Task < ApplicationRecord
 
   scope :newest, -> { order(created_at: :desc) }
   scope :not_archived, -> { where.not(status: :archived).or(Task.where(status: nil)) }
+  scope :exclude_unassigned, -> { where.not(status: nil).or(Task.where.not(user_id: nil)) }
 
   def assign_user
     update(user: list.ordered_users.detect { |user| acceptable_candidate?(user) })

--- a/spec/models/list_spec.rb
+++ b/spec/models/list_spec.rb
@@ -60,6 +60,13 @@ RSpec.describe List, type: :model do
       expect(list.tasks.count).to eq(0)
       expect(list.ordered_users).to eq([users(:aldhsu), users(:alex), users(:dave), users(:tate)])
     end
+
+    it "is not affected by 'unassigned' tasks" do
+      list.tasks.create!(description: "asdf", user: users(:aldhsu), status: :reassigned)
+      list.tasks.create!(description: "rails (5.0.2.rc1)", user: nil, status: nil)
+      expect(list.tasks.size).to eq(2)
+      expect(list.ordered_users).to eq([users(:alex), users(:dave), users(:tate), users(:aldhsu)])
+    end
   end
 
   describe "#instigator_excluded?" do

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -52,6 +52,22 @@ RSpec.describe Task, type: :model do
     end
   end
 
+  describe ".exclude_unassigned" do
+    it "excludes tasks where status and user is nil" do
+      Task.destroy_all
+
+      defaults = {
+        description: "hh",
+        list: lists(:pull_request),
+      }
+      t1 = Task.create!(defaults.merge(status: nil, user: users(:alex)))
+      t2 = Task.create!(defaults.merge(status: nil, user: nil))
+      t3 = Task.create!(defaults.merge(status: :accepted, user: users(:alex)))
+      t4 = Task.create!(defaults.merge(status: :accepted, user: nil))
+      expect(Task.exclude_unassigned).to contain_exactly(t1, t3, t4)
+    end
+  end
+
   describe ".not_archived" do
     it "excludes archived tasks" do
       Task.destroy_all

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -52,6 +52,21 @@ RSpec.describe Task, type: :model do
     end
   end
 
+  describe ".not_archived" do
+    it "excludes archived tasks" do
+      Task.destroy_all
+      defaults = {
+        description: "hh",
+        list: lists(:pull_request),
+      }
+      t1 = Task.create!(defaults.merge(status: nil))
+      t2 = Task.create!(defaults.merge(status: :archived))
+      t3 = Task.create!(defaults.merge(status: :reassigned))
+      t4 = Task.create!(defaults.merge(status: :accepted))
+      expect(Task.not_archived).to contain_exactly(t1, t3, t4)
+    end
+  end
+
   describe "#assign_user" do
     it "excludes the instigator if requested by the list" do
       list = lists(:pull_request)


### PR DESCRIPTION
Add scope tests.

Update ordered users to exclude unassigned tasks.