### PR TITLE
Use Pry in production

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,12 +4,9 @@ ruby "2.5.1"
 
 gem "jbuilder"
 gem "pg"
+gem "pry-rails"
 gem "puma"
 gem "rails", "5.2.0"
-
-group :development, :test do
-  gem "byebug"
-end
 
 group :development do
   gem "listen"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,7 +46,7 @@ GEM
       public_suffix (>= 2.0.2, < 4.0)
     arel (9.0.0)
     builder (3.2.3)
-    byebug (10.0.2)
+    coderay (1.1.2)
     concurrent-ruby (1.0.5)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
@@ -83,6 +83,11 @@ GEM
     nokogiri (1.8.2)
       mini_portile2 (~> 2.3.0)
     pg (1.0.0)
+    pry (0.11.3)
+      coderay (~> 1.1.0)
+      method_source (~> 0.9.0)
+    pry-rails (0.3.6)
+      pry (>= 0.10.4)
     public_suffix (3.0.2)
     puma (3.11.4)
     rack (2.0.5)
@@ -166,10 +171,10 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  byebug
   jbuilder
   listen
   pg
+  pry-rails
   puma
   rails (= 5.2.0)
   rspec-rails

--- a/config/initializers/pry.rb
+++ b/config/initializers/pry.rb
@@ -1,0 +1,8 @@
+Pry.config.prompt_name = :robin
+color = Rails.env.production? ? :red : :cyan
+prefix = Pry::Helpers::Text.public_send(color, Rails.env.upcase)
+
+Pry.config.prompt = [
+  proc { |*args| "#{prefix} #{Pry::DEFAULT_PROMPT.first.call(*args)}" },
+  proc { |*args| "#{prefix} #{Pry::DEFAULT_PROMPT.second.call(*args)}" },
+]


### PR DESCRIPTION
An experiment to use Pry in production. Following advice from [a Bugsnag blog article](https://blog.bugsnag.com/production-pry/), an initialiser customises the prompt to add extra attention to the environment - red in production, cyan otherwise.

<img width="540" alt="screen_shot_2018-05-26_at_4_07_40_pm" src="https://user-images.githubusercontent.com/3786095/40573098-2ad89a5e-60ff-11e8-8e56-d452195e74ca.png">