### PR TITLE
Various changes to models

### DIFF
--- a/app/models/list.rb
+++ b/app/models/list.rb
@@ -10,7 +10,7 @@ class List < ApplicationRecord
 
   def ordered_users
     list_users = users.alphabetically.to_a
-    latest_task_user = tasks.exclude_unassigned.not_archived.newest.first&.user
+    latest_task_user = tasks.not_unassigned.not_archived.newest.first&.user
     count = list_users.index(latest_task_user)&.succ || 0
     list_users.rotate(count)
   end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -11,31 +11,22 @@ class Task < ApplicationRecord
   scope :not_archived, -> { where.not(status: :archived).or(Task.where(status: nil)) }
   scope :exclude_unassigned, -> { where.not(status: nil).or(Task.where.not(user_id: nil)) }
 
+  delegate :name, :webhook_token, to: :list, prefix: true
+  delegate :slack_channel_id, to: :list
+
   def assign_user
     update(user: list.ordered_users.detect { |user| acceptable_candidate?(user) })
     user
   end
 
-  def list_name
-    list.name
-  end
-
-  def list_webhook_token
-    list.webhook_token
-  end
-
-  def slack_channel_id
-    list.slack_channel_id
-  end
-
   def slack_user_id
-    user.slack_id
+    user&.slack_id
   end
 
   private
 
-  def acceptable_candidate?(candidate)
-    !candidate.excluded? &&
-      !(list.instigator_excluded? && candidate == instigator)
+  def acceptable_candidate?(user)
+    !user.excluded? &&
+      !(list.instigator_excluded? && user == instigator)
   end
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -3,19 +3,30 @@ class Task < ApplicationRecord
   belongs_to :user, optional: true
   belongs_to :instigator, class_name: "User", optional: true
 
-  enum status: [:accepted, :reassigned, :archived]
+  enum status: [:accepted, :reassigned, :archived, :unassigned, :assigned]
 
   validates :description, presence: true
+  validates :status, presence: true
+  validates :user, absence: true, if: :unassigned?
+  validates :user, presence: true, unless: :unassigned?
 
   scope :newest, -> { order(created_at: :desc) }
-  scope :not_archived, -> { where.not(status: :archived).or(Task.where(status: nil)) }
-  scope :exclude_unassigned, -> { where.not(status: nil).or(Task.where.not(user_id: nil)) }
+  scope :not_archived, -> { where.not(status: :archived) }
+  scope :not_unassigned, -> { where.not(status: :unassigned) }
 
   delegate :name, :webhook_token, to: :list, prefix: true
   delegate :slack_channel_id, to: :list
 
   def assign_user
-    update(user: list.ordered_users.detect { |user| acceptable_candidate?(user) })
+    new_user = list.ordered_users.detect { |user| acceptable_candidate?(user) }
+
+    if new_user
+      update(
+        status: :assigned,
+        user: new_user,
+      )
+    end
+
     user
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,6 @@
 class User < ApplicationRecord
   has_and_belongs_to_many :lists
-  has_many :tasks
+  has_many :tasks, dependent: :destroy
 
   validates :slack_id, presence: true
   validates :slack_name, presence: true

--- a/db/migrate/20180526125127_change_status_null_on_tasks.rb
+++ b/db/migrate/20180526125127_change_status_null_on_tasks.rb
@@ -1,0 +1,6 @@
+class ChangeStatusNullOnTasks < ActiveRecord::Migration[5.2]
+  def change
+    change_column_null :tasks, :status, false
+    add_index :tasks, :status
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180504053240) do
+ActiveRecord::Schema.define(version: 2018_05_26_125127) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -38,10 +38,11 @@ ActiveRecord::Schema.define(version: 20180504053240) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "user_id"
-    t.integer "status"
+    t.integer "status", null: false
     t.bigint "instigator_id"
     t.index ["instigator_id"], name: "index_tasks_on_instigator_id"
     t.index ["list_id"], name: "index_tasks_on_list_id"
+    t.index ["status"], name: "index_tasks_on_status"
     t.index ["user_id"], name: "index_tasks_on_user_id"
   end
 

--- a/spec/fixtures/tasks.yml
+++ b/spec/fixtures/tasks.yml
@@ -14,3 +14,4 @@ standup2:
   user: alex
   list: standup
   description: You start today
+  status: assigned

--- a/spec/models/list_spec.rb
+++ b/spec/models/list_spec.rb
@@ -86,9 +86,9 @@ RSpec.describe List, type: :model do
       expect(list.ordered_users).to eq([users(:aldhsu), users(:alex), users(:dave), users(:tate)])
     end
 
-    it "is not affected by 'unassigned' tasks" do
+    it "is not affected by unassigned tasks" do
       list.tasks.create!(description: "asdf", user: users(:aldhsu), status: :reassigned)
-      list.tasks.create!(description: "rails (5.0.2.rc1)", user: nil, status: nil)
+      list.tasks.create!(description: "rails (5.0.2.rc1)", user: nil, status: :unassigned)
       expect(list.tasks.size).to eq(2)
       expect(list.ordered_users).to eq([users(:alex), users(:dave), users(:tate), users(:aldhsu)])
     end

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -17,6 +17,15 @@ RSpec.describe Task, type: :model do
       task = Task.new(user: user)
       expect(task.slack_user_id).to eq("U1")
     end
+
+    it "is nil if without user" do
+      task = Task.create!(
+        description: "asdf",
+        list: lists(:test),
+        user: nil,
+      )
+      expect(task.slack_user_id).to be_nil
+    end
   end
 
   describe "#instigator_id" do

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe Task, type: :model do
       task = Task.create!(
         description: "asdf",
         list: lists(:test),
+        status: :unassigned,
         user: nil,
       )
       expect(task.slack_user_id).to be_nil
@@ -32,9 +33,10 @@ RSpec.describe Task, type: :model do
     it "may have instigator" do
       task = Task.new(
         description: "hh",
-        user: users(:alex),
         instigator: users(:tate),
         list: lists(:outofdate),
+        status: :assigned,
+        user: users(:alex),
       )
       expect(task.save).to eq(true)
     end
@@ -42,53 +44,77 @@ RSpec.describe Task, type: :model do
     it "may not have instigator" do
       task = Task.new(
         description: "hh",
-        user: users(:alex),
         instigator: nil,
         list: lists(:outofdate),
+        status: :assigned,
+        user: users(:alex),
       )
       expect(task.save).to eq(true)
     end
   end
 
   describe "#user_id" do
-    it "may not have a user" do
+    it "may be nil if unassigned" do
       task = Task.new(
         description: "hh",
-        user:nil,
         list: lists(:outofdate),
+        user: nil,
+        status: :unassigned,
       )
       expect(task.save).to eq(true)
     end
   end
 
-  describe ".exclude_unassigned" do
-    it "excludes tasks where status and user is nil" do
-      Task.destroy_all
+  describe ".not_unassigned" do
+    before(:example) { Task.destroy_all }
 
-      defaults = {
-        description: "hh",
+    let(:defaults) do
+      {
+        description: "asdf",
         list: lists(:pull_request),
+        user: users(:alex),
       }
-      t1 = Task.create!(defaults.merge(status: nil, user: users(:alex)))
-      t2 = Task.create!(defaults.merge(status: nil, user: nil))
-      t3 = Task.create!(defaults.merge(status: :accepted, user: users(:alex)))
-      t4 = Task.create!(defaults.merge(status: :accepted, user: nil))
-      expect(Task.exclude_unassigned).to contain_exactly(t1, t3, t4)
+    end
+
+    it "excludes unassigned tasks" do
+      Task.create!(defaults.merge(status: :unassigned, user: nil))
+      expect(Task.not_unassigned).to be_empty
+    end
+
+    Task.statuses.except(:unassigned).each_key do |status|
+      it "includes #{status} tasks" do
+        task = Task.create!(defaults.merge(status: status.to_sym))
+        expect(Task.not_unassigned).to contain_exactly(task)
+      end
     end
   end
 
   describe ".not_archived" do
-    it "excludes archived tasks" do
-      Task.destroy_all
-      defaults = {
-        description: "hh",
+    before(:example) { Task.destroy_all }
+
+    let(:defaults) do
+      {
+        description: "asdf",
         list: lists(:pull_request),
+        user: users(:alex),
       }
-      t1 = Task.create!(defaults.merge(status: nil))
-      t2 = Task.create!(defaults.merge(status: :archived))
-      t3 = Task.create!(defaults.merge(status: :reassigned))
-      t4 = Task.create!(defaults.merge(status: :accepted))
-      expect(Task.not_archived).to contain_exactly(t1, t3, t4)
+    end
+
+    it "excludes archived tasks" do
+      Task.create!(defaults.merge(status: :archived))
+      expect(Task.not_archived).to be_empty
+    end
+
+    Task.statuses.except(:archived, :unassigned).each_key do |status|
+      it "includes #{status} tasks" do
+        task = Task.create!(defaults.merge(status: status.to_sym))
+        expect(Task.not_archived).to contain_exactly(task)
+      end
+    end
+
+    it "includes unassigned tasks" do
+      task = Task.create!(defaults.merge(status: :unassigned, user: nil))
+      expect(Task.not_archived).to contain_exactly(task)
     end
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe User, type: :model do
   fixtures :users
-  
+
   describe "#excluded?" do
     it "returns true for current excluded user data" do
       user = users(:alex)

--- a/spec/operations/create_task_operation_spec.rb
+++ b/spec/operations/create_task_operation_spec.rb
@@ -14,9 +14,9 @@ RSpec.describe CreateTaskOperation do
       )
     end
 
-    it "creates a task with a nil status" do
+    it "creates an assigned task" do
       expect { call_operation }.to change { Task.count }.by(1)
-      expect(Task.last.status).to be_nil
+      expect(Task.last).to be_assigned
     end
 
     it "is a success" do
@@ -51,8 +51,16 @@ RSpec.describe CreateTaskOperation do
     end
 
     context "when no candidates available" do
-      it "still posts the unassigned task to Slack" do
+      before(:example) do
         users(:tate).update(excluded_at: Time.current.beginning_of_minute)
+      end
+
+      it "creates an unassigned task" do
+        expect { call_operation }.to change { Task.count }.by(1)
+        expect(Task.last).to be_unassigned
+      end
+
+      it "still posts the unassigned task to Slack" do
         call_operation
         expect(CreateSlackMessageJob).to have_been_enqueued_with_arguments(
           channel: list.slack_channel_id,


### PR DESCRIPTION
A handful of things that I noticed while working with Jack:
- webhook_token may be customised
- some of the `Task` methods could be expressed with delegation
- added error when destroying `User` with tasks
- two new `status`:
  - `:unassigned`
  - `:assigned`
- `tasks.status` cannot be `NULL`

The flow of a task now looks like:
1. Enters the system with `user: nil, status: :unassigned`
1. Gets assigned a user, `status: :assigned`
1. May branch from there to `:accepted`, `:reassigned`, or `:archived`

I've already tidied the production data, there are no tasks with `status = NULL` (excluding any new ones that come in while this pull request is open).